### PR TITLE
Revert "Bump python from 3.9.23-slim-bookworm to 3.14.3-slim-bookworm in /infrastructure/production/django"

### DIFF
--- a/infrastructure/production/django/Dockerfile
+++ b/infrastructure/production/django/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.3-slim-bookworm AS python
+FROM python:3.9.23-slim-bookworm AS python
 
 # Python build stage ----------------------------------------------------------
 FROM python AS python-build-stage


### PR DESCRIPTION
Reverts uccser/codewof#1323
This should not have happened, have already applied fix to dependabot yml file