### PR TITLE
Upgrade intro.js from 6.0.0 to 8.3.2

### DIFF
--- a/codewof/package-lock.json
+++ b/codewof/package-lock.json
@@ -30,7 +30,7 @@
                 "gulp-sourcemaps": "3.0.0",
                 "gulp-tap": "2.0.0",
                 "gulp-terser": "2.1.0",
-                "intro.js": "6.0.0",
+                "intro.js": "8.3.2",
                 "jquery": "3.7.1",
                 "pixrem": "5.0.0",
                 "popper.js": "1.16.1",
@@ -866,19 +866,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/array-union": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
-            "integrity": "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/asn1.js": {
@@ -2588,6 +2575,39 @@
                 "url": "https://github.com/sponsors/fb55"
             }
         },
+        "node_modules/css-select/node_modules/domhandler": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "optional": true,
+            "dependencies": {
+                "domelementtype": "^2.2.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/css-select/node_modules/domutils": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "optional": true,
+            "dependencies": {
+                "dom-serializer": "^1.0.1",
+                "domelementtype": "^2.2.0",
+                "domhandler": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
         "node_modules/css-tree": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
@@ -3182,6 +3202,34 @@
                 "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
             }
         },
+        "node_modules/dom-serializer/node_modules/domhandler": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "optional": true,
+            "dependencies": {
+                "domelementtype": "^2.2.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/dom-serializer/node_modules/entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "optional": true,
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "node_modules/domain-browser": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -3207,14 +3255,13 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/domhandler": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "optional": true,
             "dependencies": {
-                "domelementtype": "^2.2.0"
+                "domelementtype": "^2.3.0"
             },
             "engines": {
                 "node": ">= 4"
@@ -3224,19 +3271,33 @@
             }
         },
         "node_modules/domutils": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "optional": true,
             "dependencies": {
-                "dom-serializer": "^1.0.1",
-                "domelementtype": "^2.2.0",
-                "domhandler": "^4.2.0"
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3"
             },
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/domutils/node_modules/dom-serializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
             }
         },
         "node_modules/dot-prop": {
@@ -3462,12 +3523,14 @@
             }
         },
         "node_modules/entities": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "optional": true,
+            "engines": {
+                "node": ">=0.12"
+            },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
@@ -5886,9 +5949,9 @@
             }
         },
         "node_modules/intro.js": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/intro.js/-/intro.js-6.0.0.tgz",
-            "integrity": "sha512-ZUiR6BoLSvPSlLG0boewnWVgji1fE1gBvP/pyw5pgCKXEDQz1mMeUxarggClPNs71UTq364LwSk9zxz17A9gaQ==",
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/intro.js/-/intro.js-8.3.2.tgz",
+            "integrity": "sha512-+QsuU8P7Z/O7stAwZ8Uj6CPyKsY6xVx/7hKTVLjlIEPYHaT43XnEUUYHCln6Ehr7GlDuwczh6I8PD/HGf4EG0A==",
             "dev": true,
             "license": "AGPL-3.0"
         },
@@ -6855,6 +6918,19 @@
             },
             "engines": {
                 "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/multimatch/node_modules/array-union": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
+            "integrity": "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -8264,65 +8340,6 @@
             "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
             "dev": true,
             "license": "CC0-1.0"
-        },
-        "node_modules/postcss-svgo/node_modules/dom-serializer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.2",
-                "entities": "^4.2.0"
-            },
-            "funding": {
-                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-            }
-        },
-        "node_modules/postcss-svgo/node_modules/domhandler": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "domelementtype": "^2.3.0"
-            },
-            "engines": {
-                "node": ">= 4"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domhandler?sponsor=1"
-            }
-        },
-        "node_modules/postcss-svgo/node_modules/domutils": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "dom-serializer": "^2.0.0",
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domutils?sponsor=1"
-            }
-        },
-        "node_modules/postcss-svgo/node_modules/entities": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
         },
         "node_modules/postcss-svgo/node_modules/mdn-data": {
             "version": "2.27.1",

--- a/codewof/package.json
+++ b/codewof/package.json
@@ -25,7 +25,7 @@
         "gulp-sourcemaps": "3.0.0",
         "gulp-tap": "2.0.0",
         "gulp-terser": "2.1.0",
-        "intro.js": "6.0.0",
+        "intro.js": "8.3.2",
         "jquery": "3.7.1",
         "pixrem": "5.0.0",
         "popper.js": "1.16.1",

--- a/codewof/static/js/question_types/debugging.js
+++ b/codewof/static/js/question_types/debugging.js
@@ -48,17 +48,7 @@ $(document).ready(async function () {
 
     setTutorialAttributes();
     $("#introjs-tutorial").click(function () {
-        introJS().start().onbeforechange(function () {
-            currentElement = $(this._introItems[this._currentStep].element);
-            node = currentElement.prop('nodeName');
-            // When looking at a full row of the table, force it to scroll to the far left
-            // so the highlight only overhangs to the right
-            if (node == 'TABLE' || node == 'TR') {
-                currentElement = currentElement.find('td:first-of-type')
-            }
-            containerId = 'table-container';
-            base.scroll_to_element(containerId, currentElement);
-        });
+        introJS().start();
     });
 });
 

--- a/codewof/static/js/question_types/function.js
+++ b/codewof/static/js/question_types/function.js
@@ -42,17 +42,7 @@ $(document).ready(async function () {
 
     setTutorialAttributes();
     $("#introjs-tutorial").click(function () {
-        introJS().start().onbeforechange(function () {
-            currentElement = $(this._introItems[this._currentStep].element);
-            node = currentElement.prop('nodeName');
-            // When looking at a full row of the table, force it to scroll to the far left
-            // so the highlight only overhangs to the right
-            if (node == 'TABLE' || node == 'TR') {
-                currentElement = currentElement.find('td:first-of-type')
-            }
-            containerId = 'table-container';
-            base.scroll_to_element(containerId, currentElement);
-        });
+        introJS().start();
     });
 });
 

--- a/codewof/static/js/question_types/parsons.js
+++ b/codewof/static/js/question_types/parsons.js
@@ -51,17 +51,7 @@ $(document).ready(async function(){
 
     setTutorialAttributes();
     $("#introjs-tutorial").click(function() {
-        introJS().start().onbeforechange(function() {
-            currentElement = $(this._introItems[this._currentStep].element);
-            node = currentElement.prop('nodeName');
-            // When looking at a full row of the table, force it to scroll to the far left
-            // so the highlight only overhangs to the right
-            if (node == 'TABLE' || node == 'TR') {
-                currentElement = currentElement.find('td:first-of-type')
-            }
-            containerId = 'table-container';
-            base.scroll_to_element(containerId, currentElement);
-        });
+        introJS().start();
     });
 });
 

--- a/codewof/static/js/question_types/program.js
+++ b/codewof/static/js/question_types/program.js
@@ -41,17 +41,7 @@ $(document).ready(async function () {
 
     setTutorialAttributes();
     $("#introjs-tutorial").click(function () {
-        introJS().start().onbeforechange(function () {
-            currentElement = $(this._introItems[this._currentStep].element);
-            node = currentElement.prop('nodeName');
-            // When looking at a full row of the table, force it to scroll to the far left
-            // so the highlight only overhangs to the right
-            if (node == 'TABLE' || node == 'TR') {
-                currentElement = currentElement.find('td:first-of-type')
-            }
-            containerId = 'table-container';
-            base.scroll_to_element(containerId, currentElement);
-        });
+        introJS().start();
     });
 });
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -35,6 +35,7 @@ services:
     volumes:
       # https://burnedikt.com/dockerized-node-development-and-mounting-node-volumes/#exclude-node_modules-from-the-mount
       - ./codewof/package.json:/app/package.json:z
+      - ./codewof/package-lock.json:/app/package-lock.json:z
       - ./codewof/gulpfile.js:/app/gulpfile.js:z
       - ./codewof/static:/app/static:z
       - ./codewof/build:/app/build:z


### PR DESCRIPTION
## Summary

- Fixes Dependabot PR #1199 (bump intro.js 6.0.0 → 8.3.2)
- Removes `onbeforechange` callback that accessed private internal properties (`_introItems`, `_currentStep`) which no longer exist in v8, causing a console error
- The removed code was a scroll-to-element workaround added in 2020 — its absence has no functional impact on the tutorial
- Also mounts `package-lock.json` in the node container so `npm install` updates it on the host

## Test plan

- [x] Tutorial works on all question types (function, program, debugging, parsons)
- [x] No console errors when running the tutorial

🤖 Generated with [Claude Code](https://claude.com/claude-code)