### PR TITLE
Remove django-activeurl

### DIFF
--- a/codewof/config/settings/base.py
+++ b/codewof/config/settings/base.py
@@ -101,7 +101,6 @@ THIRD_PARTY_APPS = [
     'allauth.account',
     'allauth.socialaccount',
     'rest_framework',
-    'django_activeurl',
     'svg',
     'ckeditor',
     'django_recaptcha',
@@ -298,18 +297,6 @@ MIGRATION_MODULES = {
     "socialaccount": "allauth.socialaccount.migrations",
 }
 
-# django-activeurl
-# ------------------------------------------------------------------------------
-ACTIVE_URL_KWARGS = {
-    'css_class': 'active',
-    'parent_tag': 'li',
-    'menu': 'yes',
-    'ignore_params': 'no'
-}
-
-ACTIVE_URL_CACHE = True
-ACTIVE_URL_CACHE_TIMEOUT = 60 * 60 * 24  # 1 day
-ACTIVE_URL_CACHE_PREFIX = 'django_activeurl'
 
 # django-rest-framework
 # ------------------------------------------------------------------------------

--- a/codewof/templates/base.html
+++ b/codewof/templates/base.html
@@ -1,4 +1,4 @@
-{% load static i18n activeurl svg django_bootstrap_breadcrumbs i18n %}
+{% load static i18n svg django_bootstrap_breadcrumbs i18n %}
 
 <!doctype html>
 <html lang="en">
@@ -54,7 +54,6 @@
 
         <div class="collapse navbar-collapse" id="navbarContent">
           {% if request %}
-            {% activeurl %}
             <ul id="codewof-navbar-dashboard" class="navbar-nav w-100 d-lg-flex justify-content-end align-items-stretch">
               <a class="nav-item nav-link" href="{% url 'programming:question_list' %}">
                 Questions
@@ -82,7 +81,6 @@
                 <a id="log-in-link" class="nav-item nav-link" href="{% url 'account_login' %}">{% trans "Sign In" %}</a>
               {% endif %}
             </ul>
-            {% endactiveurl %}
           {% endif %}
         </div>
       </div>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,6 @@ django-anymail[mailgun]==9.2
 django-mail-templated==2.6.5
 django-allauth==0.55.2
 django-crispy-forms==1.14.0
-django-activeurl==0.2.0
 django-autoslug==1.9.9
 djangorestframework==3.15.1
 coreapi==2.3.3


### PR DESCRIPTION
## Summary

- Removes `django-activeurl` which is unmaintained (last release 2018) and uses `urlquote` removed in Django 4.0, blocking the Django upgrade
- The `{% activeurl %}` template tag had no effect anyway — the navbar uses `<a>` tags directly rather than `<li>` elements, which is what the package looks for
- Removes the package from `requirements/base.txt`, `INSTALLED_APPS`, the template tag load, and all related settings

## Test plan

- [ ] Navbar renders correctly with no visual changes
- [ ] No Django system check errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)