### PR TITLE
Upgrade Django from 3.2.25 to 4.2.20

### DIFF
--- a/codewof/config/settings/base.py
+++ b/codewof/config/settings/base.py
@@ -104,7 +104,6 @@ THIRD_PARTY_APPS = [
     'svg',
     'ckeditor',
     'django_recaptcha',
-    'django_bootstrap_breadcrumbs',
     'django_filters',
 ]
 LOCAL_APPS = [
@@ -376,7 +375,6 @@ CODEWOF_DOMAIN = env('CODEWOF_DOMAIN', default='https://codewof.localhost')
 PRODUCTION_ENVIRONMENT = False
 STAGING_ENVIRONMENT = True
 TESTING = False
-BREADCRUMBS_TEMPLATE = 'django_bootstrap_breadcrumbs/bootstrap4.html'
 QUESTIONS_BASE_PATH = os.path.join(str(ROOT_DIR.path('programming')), 'content')
 CUSTOM_VERTO_TEMPLATES = os.path.join(str(ROOT_DIR.path('utils')), 'custom_converter_templates', '')
 

--- a/codewof/config/settings/local.py
+++ b/codewof/config/settings/local.py
@@ -83,6 +83,11 @@ INTERNAL_IPS = ['127.0.0.1', '10.0.2.2']
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = ["*"]
 
+# Django 4.0+ validates the Origin header on all requests (not just HTTPS).
+# CSRF_TRUSTED_ORIGINS must include the full scheme+host.
+# https://docs.djangoproject.com/en/4.2/ref/settings/#csrf-trusted-origins
+CSRF_TRUSTED_ORIGINS = ["https://codewof.localhost"]
+
 # django-extensions
 # ------------------------------------------------------------------------------
 # https://django-extensions.readthedocs.io/en/latest/installation_instructions.html#configuration

--- a/codewof/programming/views.py
+++ b/codewof/programming/views.py
@@ -143,6 +143,11 @@ def save_question_attempt(request):
     result = {
         'success': False,
     }
+    # NOTE: request.is_ajax() was removed in Django 4.0. This is its
+    # replacement, checking the X-Requested-With header that jQuery sets by
+    # default. This header is a convention rather than a standard — it can be
+    # spoofed or omitted by other clients. A more robust approach would be to
+    # use a dedicated API endpoint with CSRF and authentication checks.
     if request.headers.get('x-requested-with') == 'XMLHttpRequest':
         if request.user.is_authenticated:
             request_json = json.loads(request.body.decode('utf-8'))

--- a/codewof/programming/views.py
+++ b/codewof/programming/views.py
@@ -143,7 +143,7 @@ def save_question_attempt(request):
     result = {
         'success': False,
     }
-    if request.is_ajax():
+    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
         if request.user.is_authenticated:
             request_json = json.loads(request.body.decode('utf-8'))
             profile = request.user.profile

--- a/codewof/style/views.py
+++ b/codewof/style/views.py
@@ -87,6 +87,11 @@ def check_code(request):
     result = {
         'success': False,
     }
+    # NOTE: request.is_ajax() was removed in Django 4.0. This is its
+    # replacement, checking the X-Requested-With header that jQuery sets by
+    # default. This header is a convention rather than a standard — it can be
+    # spoofed or omitted by other clients. A more robust approach would be to
+    # use a dedicated API endpoint with CSRF and authentication checks.
     if request.headers.get('x-requested-with') == 'XMLHttpRequest':
         request_json = json.loads(request.body.decode('utf-8'))
         user_code = request_json['user_code']

--- a/codewof/style/views.py
+++ b/codewof/style/views.py
@@ -87,7 +87,7 @@ def check_code(request):
     result = {
         'success': False,
     }
-    if request.is_ajax():
+    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
         request_json = json.loads(request.body.decode('utf-8'))
         user_code = request_json['user_code']
         language = request_json['language']

--- a/codewof/templates/base.html
+++ b/codewof/templates/base.html
@@ -1,4 +1,4 @@
-{% load static i18n svg django_bootstrap_breadcrumbs i18n %}
+{% load static i18n svg i18n %}
 
 <!doctype html>
 <html lang="en">
@@ -100,13 +100,10 @@
         </div>
     {% endif %}
 
-    {% block breadcrumbs %}
-    {% endblock breadcrumbs %}
-
     {% block body_container %}
     <div id="page-header" class="my-3">
       <div class="container">
-        {% render_breadcrumbs %}
+        {% block breadcrumbs %}{% endblock breadcrumbs %}
         {% block page_heading %}
         {% endblock page_heading %}
       </div>

--- a/codewof/templates/style/home.html
+++ b/codewof/templates/style/home.html
@@ -1,13 +1,16 @@
 {% extends "base.html" %}
 
-{% load static svg i18n django_bootstrap_breadcrumbs %}
+{% load static svg i18n %}
 
 {% block title %}Style Checkers for schools{% endblock %}
 
 {% block breadcrumbs %}
-    {% trans "Home" as home_label %}
-    {% breadcrumb home_label "general:home" %}
-    {% breadcrumb "Style Checkers" "style:home" %}
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{% url 'general:home' %}">{% trans "Home" %}</a></li>
+    <li class="breadcrumb-item active" aria-current="page">{% trans "Style Checkers" %}</li>
+  </ol>
+</nav>
 {% endblock breadcrumbs %}
 
 {% block page_heading %}

--- a/codewof/templates/style/language-statistics.html
+++ b/codewof/templates/style/language-statistics.html
@@ -1,15 +1,18 @@
 {% extends "base.html" %}
 
-{% load static i18n django_bootstrap_breadcrumbs simplify_error_template %}
+{% load static i18n simplify_error_template %}
 
 {% block title %}{{ language.name }} Style Checker for beginners{% endblock %}
 
 {% block breadcrumbs %}
-    {% trans "Home" as home_label %}
-    {% breadcrumb home_label "general:home" %}
-    {% breadcrumb "Style Checkers" "style:home" %}
-    {% breadcrumb language.name "style:language" language.slug %}
-    {% breadcrumb "Statistics" "style:language_statistics" language.slug %}
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{% url 'general:home' %}">{% trans "Home" %}</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'style:home' %}">{% trans "Style Checkers" %}</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'style:language' language.slug %}">{{ language.name }}</a></li>
+    <li class="breadcrumb-item active" aria-current="page">{% trans "Statistics" %}</li>
+  </ol>
+</nav>
 {% endblock breadcrumbs %}
 
 {% block page_heading %}

--- a/codewof/templates/style/language.html
+++ b/codewof/templates/style/language.html
@@ -1,14 +1,17 @@
 {% extends "base.html" %}
 
-{% load static svg i18n django_bootstrap_breadcrumbs %}
+{% load static svg i18n %}
 
 {% block title %}{{ language.name }} Style Checker for beginners{% endblock %}
 
 {% block breadcrumbs %}
-    {% trans "Home" as home_label %}
-    {% breadcrumb home_label "general:home" %}
-    {% breadcrumb "Style Checkers" "style:home" %}
-    {% breadcrumb language.name "style:language" language.slug %}
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{% url 'general:home' %}">{% trans "Home" %}</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'style:home' %}">{% trans "Style Checkers" %}</a></li>
+    <li class="breadcrumb-item active" aria-current="page">{{ language.name }}</li>
+  </ol>
+</nav>
 {% endblock breadcrumbs %}
 
 {% block page_heading %}

--- a/codewof/tests/programming/loaders/test_difficulties_loader.py
+++ b/codewof/tests/programming/loaders/test_difficulties_loader.py
@@ -28,6 +28,7 @@ class DifficultiesLoaderTest(TestCase):
                 "<DifficultyLevel: Complex>",
             ],
             ordered=False,
+            transform=repr,
         )
 
     def test_insert_start(self):
@@ -55,6 +56,7 @@ class DifficultiesLoaderTest(TestCase):
                 "<DifficultyLevel: Complex>",
             ],
             ordered=False,
+            transform=repr,
         )
 
     def test_delete_end(self):
@@ -80,4 +82,5 @@ class DifficultiesLoaderTest(TestCase):
                 "<DifficultyLevel: Difficult>",
             ],
             ordered=False,
+            transform=repr,
         )

--- a/codewof/tests/programming/loaders/test_programming_concepts_loader.py
+++ b/codewof/tests/programming/loaders/test_programming_concepts_loader.py
@@ -27,6 +27,7 @@ class ProgrammingConceptsLoaderTest(TestCase):
                 "<ProgrammingConcepts: Concept 4>",
             ],
             ordered=False,
+            transform=repr,
         )
 
     def test_insert_start(self):
@@ -53,6 +54,7 @@ class ProgrammingConceptsLoaderTest(TestCase):
                 "<ProgrammingConcepts: Concept 3>",
                 "<ProgrammingConcepts: Concept 4>",
             ],
+            transform=repr,
         )
 
     def test_delete_end(self):
@@ -77,6 +79,7 @@ class ProgrammingConceptsLoaderTest(TestCase):
                 "<ProgrammingConcepts: Concept 2>",
                 "<ProgrammingConcepts: Concept 3>",
             ],
+            transform=repr,
         )
 
     def test_child_concepts_load_properly(self):
@@ -95,4 +98,5 @@ class ProgrammingConceptsLoaderTest(TestCase):
                 "<ProgrammingConcepts: Multiple Conditions>",
                 "<ProgrammingConcepts: Single Condition>",
             ],
+            transform=repr,
         )

--- a/codewof/tests/programming/loaders/test_question_contexts_loader.py
+++ b/codewof/tests/programming/loaders/test_question_contexts_loader.py
@@ -25,6 +25,7 @@ class QuestionContextsLoaderTest(TestCase):
                 "<QuestionContexts: Context 3>",
                 "<QuestionContexts: Context 4>",
             ],
+            transform=repr,
         )
 
     def test_insert_start(self):
@@ -51,6 +52,7 @@ class QuestionContextsLoaderTest(TestCase):
                 "<QuestionContexts: Context 3>",
                 "<QuestionContexts: Context 4>",
             ],
+            transform=repr,
         )
 
     def test_delete_end(self):
@@ -75,6 +77,7 @@ class QuestionContextsLoaderTest(TestCase):
                 "<QuestionContexts: Context 2>",
                 "<QuestionContexts: Context 3>",
             ],
+            transform=repr,
         )
 
     def test_child_contexts_load_properly(self):
@@ -97,4 +100,5 @@ class QuestionContextsLoaderTest(TestCase):
                 "<QuestionContexts: Mathematics>",
                 "<QuestionContexts: Simple Mathematics>",
             ],
+            transform=repr,
         )

--- a/codewof/tests/programming/loaders/test_questions_loader.py
+++ b/codewof/tests/programming/loaders/test_questions_loader.py
@@ -33,6 +33,7 @@ class QuestionsLoaderTest(DjangoTestCase):
                 "<Question: Say Hello!>",
                 "<Question: Say Hello 2!>",
             ],
+            transform=repr,
         )
 
     def test_insert_start(self):
@@ -57,6 +58,7 @@ class QuestionsLoaderTest(DjangoTestCase):
                 "<Question: Say Hello!>",
                 "<Question: Say Hello 2!>",
             ],
+            transform=repr,
         )
 
     def test_delete_end(self):
@@ -79,6 +81,7 @@ class QuestionsLoaderTest(DjangoTestCase):
             [
                 "<Question: Say Hello!>",
             ],
+            transform=repr,
         )
 
     def test_multiple_test_cases(self):
@@ -95,6 +98,7 @@ class QuestionsLoaderTest(DjangoTestCase):
                 "<TestCase: normal>",
                 "<TestCase: normal>",
             ],
+            transform=repr,
         )
 
     def test_insert_start_test_case(self):
@@ -119,6 +123,7 @@ class QuestionsLoaderTest(DjangoTestCase):
                 "<TestCase: normal>",
                 "<TestCase: normal>",
             ],
+            transform=repr,
         )
 
     def test_delete_end_test_case(self):
@@ -135,6 +140,7 @@ class QuestionsLoaderTest(DjangoTestCase):
                 "<TestCase: normal>",
                 "<TestCase: normal>",
             ],
+            transform=repr,
         )
 
         config_file = "delete-end-test-case.yaml"
@@ -149,6 +155,7 @@ class QuestionsLoaderTest(DjangoTestCase):
             [
                 "<TestCase: normal>",
             ],
+            transform=repr,
         )
 
     def test_test_case_numbers_order(self):

--- a/codewof/tests/programming/test_models.py
+++ b/codewof/tests/programming/test_models.py
@@ -175,7 +175,8 @@ class AchievementModelTests(TestCase):
                 '<Achievement: Solved five questions>',
                 '<Achievement: Solved ten questions>',
                 '<Achievement: Solved one hundred questions>',
-            ]
+            ],
+            transform=repr,
         )
 
     def test_queryset_ordering_attempts_made(self):
@@ -187,7 +188,8 @@ class AchievementModelTests(TestCase):
                 '<Achievement: Five attempts made>',
                 '<Achievement: Ten attempts made>',
                 '<Achievement: One hundred attempts made>',
-            ]
+            ],
+            transform=repr,
         )
 
 

--- a/codewof/tests/programming/test_views.py
+++ b/codewof/tests/programming/test_views.py
@@ -59,7 +59,8 @@ class QuestionListViewTest(TestCase):
                 '<Question: Test>',
                 '<Question: Test>',
             ],
-            ordered=False
+            ordered=False,
+            transform=repr,
         )
 
 

--- a/codewof/tests/style/views/test_language_statistics_view.py
+++ b/codewof/tests/style/views/test_language_statistics_view.py
@@ -115,7 +115,8 @@ class LanguageStatisticsViewTest(TestCase):
                 '<Error: python3 - error3>',
                 '<Error: python3 - error2>',
                 '<Error: python3 - error1>',
-            ]
+            ],
+            transform=repr,
         )
         self.assertEqual(
             response.context['max_count'],

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,8 +1,8 @@
 # Django
-django==3.2.25
+django==4.2.20
 django-environ==0.13.0
 django-model-utils==5.0.0
-django-anymail[mailgun]==9.2
+django-anymail[mailgun]==14.0
 django-mail-templated==2.6.5
 django-allauth==0.55.2
 django-crispy-forms==1.14.0
@@ -13,7 +13,6 @@ django-filter==22.1
 django-inline-svg==0.1.1
 django-ckeditor==6.7.0
 django-recaptcha==4.1.0
-django-bootstrap-breadcrumbs==0.9.2
 
 # Web serving
 gunicorn==24.1.1


### PR DESCRIPTION
## Summary

- Upgrade Django from 3.2.25 to 4.2.20 and django-anymail from 9.2 to 14.0
- Remove `django-bootstrap-breadcrumbs` (unmaintained, broken on Django 4.0+) and replace with inline Bootstrap 4 HTML in templates
- Replace `request.is_ajax()` (removed in Django 4.0) with `X-Requested-With` header check in programming and style views
- Fix `assertQuerysetEqual` calls to pass `transform=repr`, restoring pre-Django-4.2 behaviour where queryset items were compared as repr strings

Note: `django-activeurl` was removed separately in #1347 (already merged into develop).

## Test plan

- [x] All 382 tests passing locally
- [x] CI passes
- [x] Check breadcrumb rendering on style pages (`/style/`, `/style/<lang>/`, `/style/<lang>/statistics/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)