### PR TITLE
Fix signup broken by django-recaptcha 3→4 package upgrade

### DIFF
--- a/codewof/users/forms.py
+++ b/codewof/users/forms.py
@@ -67,7 +67,7 @@ class SignupForm(forms.Form):
             HTML(render_to_string('account/signup-declarations.html')),
             'captcha',
             HTML(render_to_string('account/recaptcha-declaration.html')),
-            Submit('submit', 'Sign Up', css_class="btn-success"),
+            Submit('signup', 'Sign Up', css_class="btn-success"),
         )
         self.fields['captcha'].label = False
 


### PR DESCRIPTION
## Summary

- The django-recaptcha package upgrade from 3.0.0 to 4.1.0 rewrote the V3 widget JS to intercept form submit and call `element.form.submit()` programmatically after obtaining a token
- A `<button name="submit">` in the signup form shadows the native `HTMLFormElement.submit` method, causing `TypeError: element.form.submit is not a function`
- Fix: rename the submit button from `name="submit"` to `name="signup"`

## Test plan

- [x] Tested locally — signup flow completes without JS errors
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)