### PR TITLE
Silence CKEditor 4 system check warning

### DIFF
--- a/codewof/config/settings/base.py
+++ b/codewof/config/settings/base.py
@@ -341,6 +341,10 @@ LOGGING = {
 
 # ckeditor
 # ------------------------------------------------------------------------------
+# Silence the CKEditor 4 security warning - CKEditor 4 is unmaintained but
+# migration is tracked in https://github.com/uccser/codewof/issues/1351
+SILENCED_SYSTEM_CHECKS = ['ckeditor.W001']
+
 CKEDITOR_UPLOAD_PATH = get_upload_path_for_date('text-editor')
 CKEDITOR_ALLOW_NONIMAGE_FILES = False
 CKEDITOR_CONFIGS = {


### PR DESCRIPTION
## Summary

- Silences `ckeditor.W001` system check warning via `SILENCED_SYSTEM_CHECKS`
- CKEditor 4 is unmaintained but migration is tracked in #1351
- Unblocks Dependabot PR #1184 (django-ckeditor 6.7.3)

## Test plan

- [x] CI passes (Django system check no longer fails on W001)